### PR TITLE
feat: split state and actor into independent Cargo features (#1)

### DIFF
--- a/apps/rustate/Cargo.toml
+++ b/apps/rustate/Cargo.toml
@@ -15,22 +15,33 @@ categories = ["algorithms", "data-structures", "development-tools"]
 crate-type = ["cdylib", "rlib"] # Add "rlib" for testing and Rust usage
 
 [features]
-default = ["tokio", "serde_json"] # Add serde_json to default features
-codegen = ["syn", "quote", "proc-macro2", "serde_json"]
-xstate-compat = ["serde_json"]
+# By default both halves are enabled, preserving backward compatibility.
+default = ["state", "actor"]
+
+# Core state-machine / statechart functionality (XState-style), usable on its own
+# without pulling in the actor runtime. Only needs Tokio's `sync` primitives
+# (used by guards/actions/transitions for the shared context lock).
+state = ["serde_json", "tokio", "tokio/sync"]
+
+# Actor-model runtime (actor system, mailboxes, spawning). This is what pulls in
+# the heavier Tokio runtime (`rt-multi-thread`, `macros`). Independent of `state`.
+actor = ["tokio", "tokio/sync", "tokio/rt-multi-thread", "tokio/macros"]
+
+codegen = ["state", "syn", "quote", "proc-macro2", "serde_json"]
+xstate-compat = ["state", "serde_json"]
 mbt = []
 property-testing = ["proptest", "rand"]
-wasm = ["wasm-bindgen", "js-sys", "console_error_panic_hook", "serde-wasm-bindgen", "wasm-bindgen-futures"] # Add serde-wasm-bindgen and wasm-bindgen-futures
-proto = ["prost", "prost-types"]
-# Add integration feature
-integration = []
+wasm = ["state", "wasm-bindgen", "js-sys", "console_error_panic_hook", "serde-wasm-bindgen", "wasm-bindgen-futures"] # Add serde-wasm-bindgen and wasm-bindgen-futures
+proto = ["codegen", "prost", "prost-types"]
+# Integration patterns build on top of the state machine layer.
+integration = ["state"]
 
 [dependencies]
 # Core
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", optional = true } # Keep optional for feature consistency, but default enables it
 async-trait = "0.1"
-tokio = { version = "1", features = ["sync", "rt-multi-thread", "macros"], optional = true } # Ensure features needed are here
+tokio = { version = "1", default-features = false, optional = true } # Tokio sub-features are selected per crate feature (`state` -> sync, `actor` -> full runtime)
 uuid = { version = "1.0", features = ["v4", "serde"] }
 tracing = { version = "0.1", features = ["log"] }
 futures = "0.3"

--- a/apps/rustate/README.md
+++ b/apps/rustate/README.md
@@ -18,6 +18,31 @@ RuState provides the following features:
 - ✅ Actor pattern support (Basic: Actor trait, ActorRef, spawn, system)
 - ❌ Model-based testing (MBT) support (Planned, not implemented)
 
+## Cargo Features
+
+The state machine and the actor model are split into two independent features so
+you only compile (and depend on) the part you actually use. Both are enabled by
+default, so existing dependencies keep working unchanged.
+
+| Feature | Enables | Notes |
+| --- | --- | --- |
+| `state` | Statecharts, guards, actions, context, transitions, integration patterns, code generation target | Only needs Tokio's `sync` primitives. |
+| `actor` | Actor trait, `ActorRef`, `spawn`, `ActorSystem` | Pulls in the full Tokio runtime (`rt-multi-thread`, `macros`). |
+
+```toml
+# Everything (default)
+rustate = "0.3"
+
+# Just the state machine — no actor runtime / lighter Tokio footprint
+rustate = { version = "0.3", default-features = false, features = ["state"] }
+
+# Just the actor model
+rustate = { version = "0.3", default-features = false, features = ["actor"] }
+```
+
+Other features (`codegen`, `xstate-compat`, `wasm`, `integration`, `proto`) build on
+top of `state` and enable it automatically.
+
 ## Model-Based Testing (MBT) Integration
 
 TODO: Implement MBT integration. (Currently not implemented)

--- a/apps/rustate/src/integration/hierarchical/mod.rs
+++ b/apps/rustate/src/integration/hierarchical/mod.rs
@@ -450,6 +450,9 @@ pub mod coordination {
         .unwrap()
     }
 
+    // `#[tokio::test]` needs Tokio's `macros` feature, which is only guaranteed
+    // under `cargo test`; gate it so plain builds (e.g. `state`-only) don't require it.
+    #[cfg(test)]
     #[tokio::test]
     async fn test_hierarchical_integration() -> crate::Result<()> {
         let child_machine = create_child_machine();

--- a/apps/rustate/src/lib.rs
+++ b/apps/rustate/src/lib.rs
@@ -5,75 +5,116 @@
 //! It forms the basis for building concurrent applications using the actor model.
 
 // Module declarations
+//
+// The crate is split into two independent halves, each behind its own Cargo
+// feature so users can compile only what they need (see the `state` / `actor`
+// features in `Cargo.toml`):
+//   * `actor` — the actor-model runtime (actor system, mailboxes, spawning).
+//   * `state` — the XState-style state machine / statechart layer.
+// Both are enabled by default; the `simple_counter` demo needs both.
+
+// --- Actor model modules (feature = "actor") ---
+#[cfg(feature = "actor")]
 pub mod actor;
+#[cfg(feature = "actor")]
 pub mod actor_ref;
+#[cfg(feature = "actor")]
 pub mod logic;
-pub mod simple_counter;
+#[cfg(feature = "actor")]
 pub mod spawn;
+#[cfg(feature = "actor")]
 pub mod system;
 
-// Add modules from obsolete crate
+// --- State machine modules (feature = "state") ---
+#[cfg(feature = "state")]
 pub mod action;
+#[cfg(feature = "state")]
 pub mod context;
+#[cfg(feature = "state")]
 pub mod error;
+#[cfg(feature = "state")]
 pub mod event;
+#[cfg(feature = "state")]
 pub mod guard;
+#[cfg(feature = "state")]
 pub mod machine;
+#[cfg(feature = "state")]
 pub mod state;
 // pub mod state_registry; // Removed - seems unused/missing
+#[cfg(feature = "state")]
 pub mod transition;
+
+// Demo actor that wires a state machine into an actor — needs both halves.
+#[cfg(all(feature = "state", feature = "actor"))]
+pub mod simple_counter;
 
 #[cfg(feature = "codegen")]
 pub mod codegen;
 #[cfg(feature = "wasm")]
 pub mod wasm;
 
-// Add integration module declaration (assuming it should always be present for now)
-// If it should be optional based on the 'integration' feature, wrap with #[cfg(feature = "integration")]
+// Integration patterns build on top of the state machine layer.
+#[cfg(feature = "state")]
 pub mod integration;
 
 // Public re-exports for easier access by users of the crate.
 
 /// The core trait defining actor behavior, state, events, and outputs.
 /// See [`actor::Actor`] for details.
+#[cfg(feature = "actor")]
 pub use actor::Actor;
 
 /// Enum representing errors that can occur within the actor system or during actor processing.
 /// See [`actor::ActorError`] for variants.
+#[cfg(feature = "actor")]
 pub use actor::ActorError;
 
 /// A reference (handle) to a spawned actor, used for sending events.
 /// See [`actor_ref::ActorRef`] for details.
+#[cfg(feature = "actor")]
 pub use actor_ref::ActorRef;
 
 /// A trait encapsulating the state transition logic (state machine behavior) of an actor.
 /// Often implemented by code generated via macros.
 /// See [`logic::ActorLogic`] for details.
+#[cfg(feature = "actor")]
 pub use logic::ActorLogic;
 
 /// Spawns an actor with the default mailbox buffer size.
 /// See [`spawn::spawn`] for details.
+#[cfg(feature = "actor")]
 pub use spawn::spawn;
 
 /// Represents the actor system, the entry point for creating top-level actors.
 /// See [`system::ActorSystem`] for details.
+#[cfg(feature = "actor")]
 pub use system::ActorSystem;
 
 // Add re-exports for types needed by machine.rs or others
 // pub use actor::{ActorStatus, Snapshot as ActorSnapshot}; // Added for MachineSnapshot - COMMENTED OUT
+#[cfg(feature = "state")]
 pub use event::{Event, IntoEvent}; // Removed duplicate EventTrait
 
 // --- Add re-exports from obsolete crate (Review and merge carefully) ---
 
 // Re-export core types from moved modules
+#[cfg(feature = "state")]
 pub use action::{Action, ActionType, IntoAction};
+#[cfg(feature = "state")]
 pub use context::Context;
+#[cfg(feature = "state")]
 pub use error::Result;
+#[cfg(feature = "state")]
 pub use error::StateError as Error;
+#[cfg(feature = "state")]
 pub use event::EventTrait;
+#[cfg(feature = "state")]
 pub use guard::{Guard, IntoGuard};
+#[cfg(feature = "state")]
 pub use machine::{Machine, MachineBuilder, MachineSnapshot};
+#[cfg(feature = "state")]
 pub use state::{HistoryType, State, StateCollection, StateTrait, StateType};
+#[cfg(feature = "state")]
 pub use transition::{Transition, TransitionType};
 
 // Actor model related re-exports from obsolete's actor.rs (may conflict/need merging)
@@ -87,7 +128,8 @@ pub use crate::wasm::*; // Re-export WASM specific items
 #[cfg(feature = "codegen")]
 pub use crate::codegen::*; // Re-export codegen specific items
 
-// Re-export integration items (no longer conditional)
+// Re-export integration items (part of the state machine layer)
+#[cfg(feature = "state")]
 pub use crate::integration::{
     context_sharing::SharedContext,
     event_forwarding::SharedMachineRef, // Assuming SharedMachineRef exists
@@ -96,7 +138,8 @@ pub use crate::integration::{
     Result as IntegrationResult,
 };
 
-// Re-export serde_json for convenience
+// Re-export serde_json for convenience (enabled together with the `state` feature)
+#[cfg(feature = "serde_json")]
 pub use serde_json;
 
 // --- Consider creating or merging a `prelude` module ---
@@ -128,8 +171,8 @@ pub mod prelude {
 }
 */
 
-// Tests module
-#[cfg(test)]
+// Tests module (exercises the counter actor, which needs both halves)
+#[cfg(all(test, feature = "state", feature = "actor"))]
 mod tests {
     // Re-import necessary items for tests
     use super::*;

--- a/apps/rustate/src/machine.rs
+++ b/apps/rustate/src/machine.rs
@@ -6,7 +6,9 @@ use crate::{
     state::{State, StateCollection, StateTrait, StateType},
     transition::{Transition, TransitionType},
 };
+#[cfg(feature = "actor")]
 use crate::{Actor, ActorError};
+#[cfg(feature = "actor")]
 use async_trait::async_trait;
 use futures::stream::{self, StreamExt};
 use log;
@@ -886,6 +888,8 @@ where
 }
 
 // Move handle_event outside the impl Actor block
+// This helper deals in actor types (`ActorError`), so it only exists with the actor feature.
+#[cfg(feature = "actor")]
 impl<C, E, S, O> Machine<C, E, S, O>
 where
     C: Clone + Default + Serialize + DeserializeOwned + Send + Sync + Debug + 'static,
@@ -932,6 +936,8 @@ where
     }
 }
 
+// Bridges the state machine into the actor model; only compiled with the actor feature.
+#[cfg(feature = "actor")]
 #[async_trait]
 impl<C, E, S, O> Actor for Machine<C, E, S, O>
 where


### PR DESCRIPTION
Closes #1.

## Summary

As suggested in #1, this separates the **state machine** and **actor model** functionality into two independent Cargo features (`state` and `actor`), XState-style, so users can compile only the part they need and avoid pulling in the heavier actor runtime when they only want statecharts.

## What changed

- **New features** `state` and `actor`. `default = ["state", "actor"]`, so existing dependants are unaffected.
- **Tokio footprint is now per-feature**: `state` only needs `tokio/sync` (the shared-context lock used by guards/actions/transitions), while `actor` pulls the full runtime (`tokio/rt-multi-thread`, `tokio/macros`). Tokio is no longer unconditionally compiled with the runtime.
- **Decoupled `state` from `actor`**: the `impl Actor for Machine` bridge (and its actor-typed helper) is now gated behind `actor`, so the state machine no longer depends on the actor module.
- Module declarations and re-exports in `lib.rs` are gated by feature; the `simple_counter` demo requires both.
- Gated a stray `#[tokio::test]` in `integration::hierarchical` behind `#[cfg(test)]` so plain builds don't require Tokio's `macros` feature.
- Documented the features in the crate README.

## Verification

All build/test configurations pass:

| Config | Result |
| --- | --- |
| `--features state,actor` (default), `cargo test --lib` | ✅ 6/6 tests pass |
| `--no-default-features --features state` | ✅ builds |
| `--no-default-features --features actor` | ✅ builds |
| `state,codegen` / `state,xstate-compat` / `state,integration` / `state,actor,codegen` | ✅ build |

🤖 Generated with [Claude Code](https://claude.com/claude-code)